### PR TITLE
Allow checking multiple buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ python3 gcpbucketbrute.py -k test -s 10
     - This argument is used to specify what keyword will be used to generate permutations with. Those permutations are what will be searched for in Google Storage.
 - `--check`
     - This argument is mutually exclusive with `-k`/`--keyword` and accepts a single string. It allows you to check your permissions on a particular bucket, rather than generating a list of permutations based on a keyword. This may be repeated to check several buckets. Credit: [@BBerastegui](https://github.com/BBerastegui)
+- `--check-list`
+    - This argument is mutually exclusive with `-k`/`--keyword` and `--check`. It allows you to check permissions of a list of buckets in a file. They should be listed one-per-line in a text file.
 - `-s`/`--subprocesses`
     - This argument specifies how many subprocesses will be used for bucket enumeration. The default is 5 and the higher you set this value, the faster enumeration will be, but your requests-per-second to Google will increase. These are essentially threads, but the script uses subprocesses instead of threads for parallel execution.
 - `-f`/`--service-account-credential-file-path`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ python3 gcpbucketbrute.py -k test -s 10
 - `--check`
     - This argument is mutually exclusive with `-k`/`--keyword` and accepts a single string. It allows you to check your permissions on a particular bucket, rather than generating a list of permutations based on a keyword. This may be repeated to check several buckets. Credit: [@BBerastegui](https://github.com/BBerastegui)
 - `--check-list`
-    - This argument is mutually exclusive with `-k`/`--keyword` and `--check`. It allows you to check permissions of a list of buckets in a file. They should be listed one-per-line in a text file.
+    - This argument is mutually exclusive with `-k`/`--keyword` and `--check`. It allows you to check permissions of a list of buckets in a file. They should be listed one-per-line in a text file. To read from standard input, pass `-` as the filename.
 - `-s`/`--subprocesses`
     - This argument specifies how many subprocesses will be used for bucket enumeration. The default is 5 and the higher you set this value, the faster enumeration will be, but your requests-per-second to Google will increase. These are essentially threads, but the script uses subprocesses instead of threads for parallel execution.
 - `-f`/`--service-account-credential-file-path`

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ python3 gcpbucketbrute.py -k test -s 10
 
 - `-k`/`--keyword`
     - This argument is used to specify what keyword will be used to generate permutations with. Those permutations are what will be searched for in Google Storage.
-- `--check-single`
-    - This argument is mutually exclusive with `-k`/`--keyword` and accepts a single string. It allows you to check your permissions on a single bucket, rather than generating a list of permutations based on a keyword. Credit: [@BBerastegui](https://github.com/BBerastegui)
+- `--check`
+    - This argument is mutually exclusive with `-k`/`--keyword` and accepts a single string. It allows you to check your permissions on a particular bucket, rather than generating a list of permutations based on a keyword. This may be repeated to check several buckets. Credit: [@BBerastegui](https://github.com/BBerastegui)
 - `-s`/`--subprocesses`
     - This argument specifies how many subprocesses will be used for bucket enumeration. The default is 5 and the higher you set this value, the faster enumeration will be, but your requests-per-second to Google will increase. These are essentially threads, but the script uses subprocesses instead of threads for parallel execution.
 - `-f`/`--service-account-credential-file-path`

--- a/gcpbucketbrute.py
+++ b/gcpbucketbrute.py
@@ -86,6 +86,9 @@ def main(args):
         buckets = generate_bucket_permutations(args.keyword)
     elif args.check:
         buckets = args.check
+    elif args.check_list:
+        with open(args.check_list, 'r') as fd:
+            buckets = fd.read().splitlines()
 
     start_time = time.time()
 
@@ -207,6 +210,7 @@ if __name__ == '__main__':
     # Add mutually exclusive arguments: keyword or a single bucket
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--check', required=False, action="append", help='Check a single bucket name instead of bruteforcing names based on a keyword. May be repeated to check multiple buckets.')
+    group.add_argument('--check-list', required=False, default=None, help='Check a list of buckets in the given file, one per line.')
     group.add_argument('-k', '--keyword', required=False, help='The base keyword to use when guessing bucket names. This could be a simple string like "Google" or a URL like "google.com" or anything else. This string is used to generate permutations to search for.')
     parser.add_argument('-s', '--subprocesses', required=False, default=5, type=int, help='The amount of subprocesses to delegate work to for enumeration. Default: 5. This is essentially how many threads you want to run the script with, but it is using subprocesses instead of threads.')
     parser.add_argument('-f', '--service-account-credential-file-path', required=False, default=None, help='The path to the JSON file that contains the private key for a GCP service account. By default, you will be prompted for a user access token, then if you decline to enter one it will prompt you to default to the default system credentials. More information here: https://google-auth.readthedocs.io/en/latest/user-guide.html#service-account-private-key-files and here: https://google-auth.readthedocs.io/en/latest/user-guide.html#user-credentials')

--- a/gcpbucketbrute.py
+++ b/gcpbucketbrute.py
@@ -84,8 +84,8 @@ def main(args):
     subprocesses = []
     if args.keyword:
         buckets = generate_bucket_permutations(args.keyword)
-    elif args.check_single:
-        buckets = [args.check_single]
+    elif args.check:
+        buckets = args.check
 
     start_time = time.time()
 
@@ -206,7 +206,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='This script will generate a list of permutations from ./permutations.txt using the keyword passed into the -k/--keyword argument. Then it will attempt to enumerate Google Storage buckets with those names without any authentication. If a bucket is found to be listable, it will be reported (buckets that allow access to "allUsers"). If a bucket is found but it is not listable, it will use the default "gcloud" CLI credentials to try and list the bucket. If the bucket is listable with credentials it will be reported (buckets that allow access to "allAuthenticatedUsers"), otherwise it will reported as existing, but unlistable.')
     # Add mutually exclusive arguments: keyword or a single bucket
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--check-single', required=False, help='Check a single bucket name instead of bruteforcing names based on a keyword.')
+    group.add_argument('--check', required=False, action="append", help='Check a single bucket name instead of bruteforcing names based on a keyword. May be repeated to check multiple buckets.')
     group.add_argument('-k', '--keyword', required=False, help='The base keyword to use when guessing bucket names. This could be a simple string like "Google" or a URL like "google.com" or anything else. This string is used to generate permutations to search for.')
     parser.add_argument('-s', '--subprocesses', required=False, default=5, type=int, help='The amount of subprocesses to delegate work to for enumeration. Default: 5. This is essentially how many threads you want to run the script with, but it is using subprocesses instead of threads.')
     parser.add_argument('-f', '--service-account-credential-file-path', required=False, default=None, help='The path to the JSON file that contains the private key for a GCP service account. By default, you will be prompted for a user access token, then if you decline to enter one it will prompt you to default to the default system credentials. More information here: https://google-auth.readthedocs.io/en/latest/user-guide.html#service-account-private-key-files and here: https://google-auth.readthedocs.io/en/latest/user-guide.html#user-credentials')

--- a/gcpbucketbrute.py
+++ b/gcpbucketbrute.py
@@ -3,6 +3,7 @@ import argparse
 import time
 import multiprocessing
 import json
+import sys
 import textwrap
 
 from functools import partial
@@ -87,7 +88,7 @@ def main(args):
     elif args.check:
         buckets = args.check
     elif args.check_list:
-        with open(args.check_list, 'r') as fd:
+        with sys.stdin if args.check_list == '-' else open(args.check_list, 'r') as fd:
             buckets = fd.read().splitlines()
 
     start_time = time.time()


### PR DESCRIPTION
This adjusts the existing `--check-single` to allow passing it more than once, so I thought `--check` is possibly a better name.

I also added an option to check a list read from a file. Following the usual convention for command-line tools, it also permits passing `-` to read from standard input.