### PR TITLE
Add an optional flag to set an exit code if public buckets are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ python3 gcpbucketbrute.py -k test -s 10
     - This argument forces unauthenticated enumeration. With this flag, you will not be prompted for credentials and valid buckets will not be checked for authenticated permissions.
 - `-o`/`--out-file`
     - This argument allows you to specify a (relative or absolute) file path to a log file to output the results to. The file will be created if it does not already exist and it will be appended to if it does already exist.
+- `-x`/`--exit`
+    - Set this flag to exit with a failing exit code (`1`) if any buckets with public access are found. If not set, the command always exits with a successful exit code (`0`).
+


### PR DESCRIPTION
This makes this script easier to use unattended in order to alert to unexpected public buckets.

I've chosen a simple exit code just for public access. At some point in the future, you may want to add other status codes to indicate other potential problems the script highlights (for example, the possibility of privilege escalation).

I'm not sure if I've unwound some deliberate behaviour in removing the while loop waiting on subprocesses; any advice would be welcome. As far as I can tell calling join once each for the subprocesses is sufficient.