### PR TITLE
Allow passing a custom bucket names wordlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ python3 gcpbucketbrute.py -k test -s 10
     - This argument forces unauthenticated enumeration. With this flag, you will not be prompted for credentials and valid buckets will not be checked for authenticated permissions.
 - `-o`/`--out-file`
     - This argument allows you to specify a (relative or absolute) file path to a log file to output the results to. The file will be created if it does not already exist and it will be appended to if it does already exist.
+- `-w`/`--wordlist`
+    - This argument allows you to specify a wordlist input file.

--- a/gcpbucketbrute.py
+++ b/gcpbucketbrute.py
@@ -56,6 +56,18 @@ def generate_bucket_permutations(keyword):
     print('\nGenerated {} bucket permutations.\n'.format(len(buckets)))
     return buckets
 
+def read_wordlist(filename):
+    try:
+        file = open(filename, 'r')
+        lines = file.read().splitlines()
+        file.close()
+        return lines
+    except FileNotFoundError:
+        print('Error: File not found')
+        exit(1)
+    except PermissionError:
+        print('Error: Permission denied')
+        exit(1)
 
 def main(args):
     if args.out_file:
@@ -85,6 +97,8 @@ def main(args):
     subprocesses = []
     if args.keyword:
         buckets = generate_bucket_permutations(args.keyword)
+    elif args.wordlist:
+        buckets = read_wordlist(args.wordlist)
     elif args.check:
         buckets = args.check
     elif args.check_list:
@@ -213,11 +227,11 @@ if __name__ == '__main__':
     group.add_argument('--check', required=False, action="append", help='Check a single bucket name instead of bruteforcing names based on a keyword. May be repeated to check multiple buckets.')
     group.add_argument('--check-list', required=False, default=None, help='Check a list of buckets in the given file, one per line.')
     group.add_argument('-k', '--keyword', required=False, help='The base keyword to use when guessing bucket names. This could be a simple string like "Google" or a URL like "google.com" or anything else. This string is used to generate permutations to search for.')
+    group.add_argument('-w', '--wordlist', required=False, default=None, help='The path to a wordlist file')
     parser.add_argument('-s', '--subprocesses', required=False, default=5, type=int, help='The amount of subprocesses to delegate work to for enumeration. Default: 5. This is essentially how many threads you want to run the script with, but it is using subprocesses instead of threads.')
     parser.add_argument('-f', '--service-account-credential-file-path', required=False, default=None, help='The path to the JSON file that contains the private key for a GCP service account. By default, you will be prompted for a user access token, then if you decline to enter one it will prompt you to default to the default system credentials. More information here: https://google-auth.readthedocs.io/en/latest/user-guide.html#service-account-private-key-files and here: https://google-auth.readthedocs.io/en/latest/user-guide.html#user-credentials')
     parser.add_argument('-u', '--unauthenticated', required=False, default=False, action='store_true', help='Force an unauthenticated scan (you will not be prompted for credentials)')
     parser.add_argument('-o', '--out-file', required=False, default=None, help='The path to a log file to write the scan results to. The file will be created if it does not exist and will append to it if it already exists. By default output will only print to the screen.')
-
     args = parser.parse_args()
 
     main(args)


### PR DESCRIPTION
This PR implements a new option `-w` that allows passing a path to a custom wordlist file.